### PR TITLE
Wrapped the functionality in a helper function.

### DIFF
--- a/tasks/closureCompiler.js
+++ b/tasks/closureCompiler.js
@@ -184,7 +184,8 @@ function compileCommand(grunt, params, data)
             }
         }
         if (!docompile) {
-            return undefined;
+            grunt.info("Skipping " + params.output_file + " (Not modified)");
+            return false;
         }
     }
     cmd += ' --js_output_file=' + params.output_file;


### PR DESCRIPTION
The compiler could only be called from its own task which was probably fine for most uses but by exposing the functionality via a grunt registered helper, it can be useful in other tasks too.

I also added a check on modification dates so that if the output file is newer than the source file(s), it won't execute the command. This speeds up builds in large projects.
