### PR TITLE
- output_file supports dynamic file names

### DIFF
--- a/tasks/closureBuilder.js
+++ b/tasks/closureBuilder.js
@@ -218,8 +218,8 @@ function compileCommand(grunt, params, data)
 
   // check if output file is defined
   if (data.output_file && data.output_file.length) {
-    cmd += ' --output_file=' + data.output_file;
-    output_file = data.output_file;
+    output_file = grunt.template.process(data.output_file);
+    cmd += ' --output_file=' + output_file;
   }
 
   // --- 


### PR DESCRIPTION
Dynamic file names for closureBuilder, too.
