### PR TITLE
DepsWriter outputs to a file named 'undefined' if configured 'output_file' does not exist

### DIFF
--- a/tasks/closureDepsWriter.js
+++ b/tasks/closureDepsWriter.js
@@ -159,6 +159,7 @@ function compileCommand(grunt, params, data)
   // check if output file is defined
   // ---
   if (data.output_file && data.output_file.length) {
+    grunt.file.write(data.output_file, ''); // Write to the file first in case it doesn't exist
     cmd += ' --output_file=' + grunt.file.expandFiles(data.output_file).shift();
   }
 


### PR DESCRIPTION
Not an ideal solution, but it works.

A better solution would be to prepend the base path of the grunt project directory to the 'output_file' variable. However I'm not familiar with the Grunt API and couldn't find a documented way of doing that.
