### PR TITLE
Make grunt a dev dependency

### DIFF
--- a/bin/grunt-closure-tools
+++ b/bin/grunt-closure-tools
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('grunt').npmTasks('grunt-closure-tools').cli();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     }
   ],
   "main": "grunt.js",
-  "bin": "bin/grunt-closure-tools",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
Since it's only required for development, doesn't make sense to install in every project.
