### PR TITLE
Fixes function call: s/.closureCompiler/.compileCommand

### DIFF
--- a/tasks/closureCompiler.js
+++ b/tasks/closureCompiler.js
@@ -35,7 +35,7 @@ module.exports = function( grunt ) {
 
     this.files.forEach(function(fileObj) {
 
-      cmd = cCompiler.closureCompiler( options, fileObj );
+      cmd = cCompiler.compileCommand( options, fileObj );
 
       if ( cmd ) {
         commands.push( {cmd: cmd, dest: targetName} );


### PR DESCRIPTION
The closureCompiler task seems to be calling a method from libCompiler that does not exist.  I was able to get the task working by making this change.
