### PR TITLE
Removes src check from validate function

### DIFF
--- a/tasks/libCompiler.js
+++ b/tasks/libCompiler.js
@@ -28,14 +28,6 @@ compiler.validate = function validate( options )
     return false;
   }
 
-  //
-  // Check for js source files
-  //
-  var src = gruntMod.file.expand(options.src);
-  if (0 === src.length) {
-    helpers.log.warn('WARNING :: "src" files not defined');
-  }
-
   return true;
 
 };


### PR DESCRIPTION
Since the closureCompiler task reads src and dest properties from target now, instead of options, it seems desirable to remove the check for a src property from options validation.

Before this change the closureCompiler task would not run unless I put a src property in the options object.  But the src property in my target took priority for actual compilation.
