### PR TITLE
Not works if *.py have no execution permission

### DIFF
--- a/lib/libBuilder.js
+++ b/lib/libBuilder.js
@@ -90,7 +90,7 @@ builder.createCommand = function createCommand ( options, fileObj ) {
   builder = gruntMod.template.process(builder);
 
 
-  var cmd = builder + ' ';
+  var cmd = 'python ' + builder + ' ';
 
   // check for inputs
   var inputs = options.inputs;

--- a/lib/libDepsWriter.js
+++ b/lib/libDepsWriter.js
@@ -53,7 +53,7 @@ depsWriter.createCommand = function createCommand( options, fileObj ) {
   // define the depsWriter executable
   var depsExec = options.depswriter || options.closureLibraryPath + DEPSWRITER;
   depsExec = gruntMod.template.process( depsExec );
-  var cmd = depsExec + ' ';
+  var cmd = 'python ' + depsExec + ' ';
   //
   // Check for root, root_with_prefix and path_with_depspath options
   //

--- a/test/builder/expected/default_options
+++ b/test/builder/expected/default_options
@@ -1,1 +1,1 @@
-path/to/builder.py  -i  --root= -o compiled --compiler_jar=path/to/compiler.jar --compiler_flags="--compilation_level=WHITESPACE_ONLY" --compiler_flags="--jscomp_off=checkTypes" --compiler_flags="--jscomp_off=strictModuleDepCheck"
+python path/to/builder.py  -i  --root= -o compiled --compiler_jar=path/to/compiler.jar --compiler_flags="--compilation_level=WHITESPACE_ONLY" --compiler_flags="--jscomp_off=checkTypes" --compiler_flags="--jscomp_off=strictModuleDepCheck"


### PR DESCRIPTION
Since I install Closure Library as a git submodule and use depswriter.py in it,
I cannot give the *.py script execution permission.
Please run them with `python` command.
