### PR TITLE
Update libBuilder.js

### DIFF
--- a/lib/libBuilder.js
+++ b/lib/libBuilder.js
@@ -46,8 +46,8 @@ builder.validate = function ( options )
   // ---
   var inputs = options.inputs || [];
   var namespaces = options.namespaces;
-  if (0 === inputs.length && !namespaces) {
-    cHelpers.log.error('src'.red + ' or ' + 'namespaces'.red +
+  if ((!inputs || 0 === inputs.length) && !namespaces) {
+    cHelpers.log.error('inputs'.red + ' or ' + 'namespaces'.red +
       ' properties are required');
     return false;
   }


### PR DESCRIPTION
If a user does not specify 'input' in his Gruntfile.js, the builder fails complaining about .length not being available on undefined.
With this small fix the user gets the right hint to either fill inputs or namespace property.
