### PR TITLE
#45 Fixed condition on create_source_map trigger for files mapping

### DIFF
--- a/tasks/closureCompiler.js
+++ b/tasks/closureCompiler.js
@@ -41,8 +41,8 @@ module.exports = function( grunt ) {
       }
       // for file mappings overwrite the source_map filename with 'dest' name + '.map' suffix
       if (isMapping && genSourceMap) {
-            options.compilerOpts.create_source_map = fileObj.dest + '.map';
-        }
+        options.compilerOpts.create_source_map = fileObj.dest + '.map';
+      }
 
       cmd = cCompiler.compileCommand( options, fileObj );
 


### PR DESCRIPTION
Hopefully the last commit to this issue - changing the condition from '!==undefined' to '===null' required moving the check before the loop as the compared value is set and is no more null in the next iteration - the case worked for file mappings of length 1, for more entries it overwrites still the same source_map file.
