### PR TITLE
Update to task-closure-tools 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "grunt": "~0.4.5",
-    "task-closure-tools": "~0.1.7"
+    "task-closure-tools": "~0.1.9"
   },
   "devDependencies": {
     "superstartup-closure-compiler": "0.1.6",


### PR DESCRIPTION
- Tests pass
- task-closure-tools 0.1.9 addresses empty src bug from
https://github.com/thanpolas/grunt-closure-tools/issues/67
- Things seem to still compile well.

![](http://media.giphy.com/media/wOLsxM1QQelS8/giphy.gif)
